### PR TITLE
PACQRPAY-1897 Update demo to version 3.2.0 with preferred mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## X SDK XX.XX.XX - 20XX-XX-XX
 
+## Revolut Pay SDK 3.2.0 - 2026-06-05
+
+### What's changed
+
+* Added preferredMode support in OrderParams (Retail, RetailOnly, Business, BusinessOnly)
+* Moved queries package declaration into the SDK manifest to simplify integration
+* Added packaging exclusion for META-INF resources to resolve build conflicts
+
+## Merchant Card Form SDK 3.2.0 - 2026-06-05
+
+### What's changed
+
+* Version alignment with Revolut Pay SDK 3.2.0
+* Added packaging exclusion for META-INF resources to resolve build conflicts
+
 ## Revolut Pay SDK 3.1.2 - 2026-01-22
 
 ### What's changed

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21'
+        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/merchant-card-form-sdk-demo/build.gradle
+++ b/merchant-card-form-sdk-demo/build.gradle
@@ -4,17 +4,26 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
     namespace "com.revolut.merchantcardformsdkdemo"
 
     defaultConfig {
         applicationId "com.revolut.merchantcardformsdkdemo"
-        minSdk 24
+        minSdk 28
         targetSdk 34
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    packaging {
+        resources {
+            excludes += [
+                    'META-INF/versions/9/OSGI-INF/MANIFEST.MF',
+                    'META-INF/versions/9/OSGI-INF/*.xml'
+            ]
+        }
     }
 
     buildTypes {
@@ -37,7 +46,7 @@ android {
 
 dependencies {
     // Revolut Merchant Card Form SDK
-    implementation 'com.revolut.payments:merchantcardform:3.1.2'
+    implementation 'com.revolut.payments:merchantcardform:3.2.0'
 
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.appcompat:appcompat:1.7.1'

--- a/revolut-pay-lite-sdk-demo/build.gradle
+++ b/revolut-pay-lite-sdk-demo/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace "com.revolut.revolutpaylite.demo"
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.revolut.revolutpaylite.demo"
-        minSdk 24
+        minSdk 28
         targetSdk 35
         versionCode 1
         versionName "1.0"
@@ -47,6 +47,14 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    packaging {
+        resources {
+            excludes += [
+                    'META-INF/versions/9/OSGI-INF/MANIFEST.MF',
+                    'META-INF/versions/9/OSGI-INF/*.xml'
+            ]
+        }
+    }
     buildFeatures {
         viewBinding true
     }
@@ -57,8 +65,8 @@ android {
 
 dependencies {
     // Revolut Pay Lite SDK
-    revolutPayLiteImplementation 'com.revolut.payments:revolutpaylite:3.1.2'
-    revolutPayImplementation 'com.revolut.payments:revolutpay:3.1.2'
+    revolutPayLiteImplementation 'com.revolut.payments:revolutpaylite:3.2.0'
+    revolutPayImplementation 'com.revolut.payments:revolutpay:3.2.0'
 
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/revolut-pay-lite-sdk-demo/src/main/AndroidManifest.xml
+++ b/revolut-pay-lite-sdk-demo/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- Declare Revolut app query: To allow the SDK to check if the Revolut app is installed. -->
-    <queries>
-        <package android:name="${revolutAppId}" />
-    </queries>
-
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/revolut-pay-lite-sdk-demo/src/main/kotlin/com/revolut/revolutpaylite/demo/payment/CustomButtonPaymentFragment.kt
+++ b/revolut-pay-lite-sdk-demo/src/main/kotlin/com/revolut/revolutpaylite/demo/payment/CustomButtonPaymentFragment.kt
@@ -49,17 +49,23 @@ class CustomButtonPaymentFragment : Fragment() {
             confirmButton.setOnClickListener {
                 externalRevolutPayOrderTokenEditText.text.toString()
                     .takeIf { it.isNotBlank() }
-                    ?.let { orderToken -> pay(orderToken, externalRevolutPaySavePaymentMethodForMerchant.isChecked) }
+                    ?.let { orderToken ->
+                        pay(
+                            orderToken = orderToken,
+                            savePaymentMethodForMerchant = externalRevolutPaySavePaymentMethodForMerchant.isChecked,
+                            requestShipping = externalRevolutPayRequestShipping.isChecked
+                        )
+                    }
             }
         }
     }
 
-    private fun pay(orderToken: String, savePaymentMethodForMerchant: Boolean) {
+    private fun pay(orderToken: String, savePaymentMethodForMerchant: Boolean, requestShipping: Boolean) {
         paymentController.pay(
             orderParams = OrderParams(
                 orderToken = orderToken,
                 returnUri = "payments://revolut-pay-demo".toUri(),
-                requestShipping = false,
+                requestShipping = requestShipping,
                 savePaymentMethodForMerchant = savePaymentMethodForMerchant,
                 customer = null
             )

--- a/revolut-pay-lite-sdk-demo/src/main/kotlin/com/revolut/revolutpaylite/demo/payment/RevolutPayButtonPaymentFragment.kt
+++ b/revolut-pay-lite-sdk-demo/src/main/kotlin/com/revolut/revolutpaylite/demo/payment/RevolutPayButtonPaymentFragment.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Spinner
 import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
@@ -13,6 +15,7 @@ import com.revolut.payments.RevolutPaymentsSDK
 import com.revolut.revolutpay.api.PaymentResult
 import com.revolut.revolutpay.api.bindPaymentState
 import com.revolut.revolutpay.api.order.OrderParams
+import com.revolut.revolutpay.api.order.PreferredMode
 import com.revolut.revolutpay.api.revolutPay
 import com.revolut.revolutpaylite.demo.R
 import kotlinx.coroutines.delay
@@ -56,6 +59,19 @@ class RevolutPayButtonPaymentFragment : Fragment() {
             externalRevolutPayRevolutPayButtonExtraSmallWithoutBox.setOnClickListener {
                 fetchParamsAndPay()
             }
+
+            setupPreferredModeSpinner()
+        }
+    }
+
+    private fun Binding.setupPreferredModeSpinner() {
+        ArrayAdapter.createFromResource(
+            requireContext(),
+            R.array.preferred_mode,
+            android.R.layout.simple_spinner_item,
+        ).also { adapter ->
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            externalRevolutPayPreferredMode.adapter = adapter
         }
     }
 
@@ -79,13 +95,25 @@ class RevolutPayButtonPaymentFragment : Fragment() {
 
     private suspend fun fetchOrderParams(): OrderParams {
         delay(500)
+        val binding = requireNotNull(binding)
         return OrderParams(
-            orderToken = requireNotNull(binding).externalRevolutPayOrderTokenEditText.text.toString(),
+            orderToken = binding.externalRevolutPayOrderTokenEditText.text.toString(),
             returnUri = "payments://revolut-pay-demo".toUri(),
-            requestShipping = false,
+            requestShipping = binding.externalRevolutPayRequestShipping.isChecked,
             customer = null,
-            savePaymentMethodForMerchant = requireNotNull(binding).externalRevolutPaySavePaymentMethodForMerchant.isChecked,
+            savePaymentMethodForMerchant = binding.externalRevolutPaySavePaymentMethodForMerchant.isChecked,
+            preferredMode = binding.externalRevolutPayPreferredMode.getPreferredMode(),
         )
+    }
+
+    private fun Spinner.getPreferredMode(): PreferredMode {
+        return when (selectedItem.toString().uppercase()) {
+            "RETAIL" -> PreferredMode.Retail
+            "RETAIL-ONLY" -> PreferredMode.RetailOnly
+            "BUSINESS" -> PreferredMode.Business
+            "BUSINESS-ONLY" -> PreferredMode.BusinessOnly
+            else -> PreferredMode.Retail
+        }
     }
 
     override fun onDestroyView() {

--- a/revolut-pay-lite-sdk-demo/src/main/res/layout/fragment_custom_button_payment.xml
+++ b/revolut-pay-lite-sdk-demo/src/main/res/layout/fragment_custom_button_payment.xml
@@ -17,6 +17,7 @@
         android:id="@+id/externalRevolutPay_OrderToken_EditText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:inputType="textNoSuggestions"
         android:fontFamily="sans-serif-medium" />
 
     <Button
@@ -31,6 +32,13 @@
         android:layout_height="wrap_content"
         android:text="@string/revolut_pay_save_payment_method_for_merchant"
         android:layout_marginTop="16dp" />
+
+    <CheckBox
+        android:id="@+id/externalRevolutPay_RequestShipping"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/revolut_pay_request_shipping" />
 
     <Button
         android:id="@+id/confirm_button"

--- a/revolut-pay-lite-sdk-demo/src/main/res/layout/fragment_revolut_pay_button_payment.xml
+++ b/revolut-pay-lite-sdk-demo/src/main/res/layout/fragment_revolut_pay_button_payment.xml
@@ -18,7 +18,8 @@
         android:id="@+id/externalRevolutPay_OrderToken_EditText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fontFamily="sans-serif-medium" />
+        android:fontFamily="sans-serif-medium"
+        android:inputType="textNoSuggestions" />
 
     <Button
         android:id="@+id/externalRevolutPay_ClearOrderToken"
@@ -32,6 +33,36 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:text="@string/revolut_pay_save_payment_method_for_merchant" />
+
+    <CheckBox
+        android:id="@+id/externalRevolutPay_RequestShipping"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/revolut_pay_request_shipping" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:paddingHorizontal="5dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            android:text="@string/revolut_pay_preferred_mode" />
+
+        <Spinner
+            android:id="@+id/externalRevolutPay_PreferredMode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="#ffdedede"
+            android:layout_marginStart="5dp"
+            android:paddingVertical="5dp" />
+
+    </LinearLayout>
 
     <com.revolut.revolutpay.api.RevolutPayButton
         android:id="@+id/externalRevolutPay_RevolutPayButton_ExtraSmall_WithoutBox"

--- a/revolut-pay-lite-sdk-demo/src/main/res/values/arrays.xml
+++ b/revolut-pay-lite-sdk-demo/src/main/res/values/arrays.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="preferred_mode">
+        <item>Retail</item>
+        <item>Retail-Only</item>
+        <item>Business</item>
+        <item>Business-Only</item>
+    </string-array>
+</resources>

--- a/revolut-pay-lite-sdk-demo/src/main/res/values/strings.xml
+++ b/revolut-pay-lite-sdk-demo/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="revolut_pay_revolut_app_installation_check">Revolut Application Installation Check</string>
     <string name="revolut_pay_uikit_showcase">UiKit Showcase</string>
     <string name="revolut_pay_save_payment_method_for_merchant">Save Payment Method for Merchant</string>
+    <string name="revolut_pay_request_shipping">Request shipping</string>
+    <string name="revolut_pay_preferred_mode">Preferred mode:</string>
     <string name="order_token_clear">Clear order token</string>
     <string name="order_token_title">Order token</string>
     <string name="order_completed">Order completed</string>


### PR DESCRIPTION
- Update SDK version in Revolut Pay and Cardform to SDK 3.2.0
- Add Preferred Mode spinner in Revolut Pay SDK Demo app for selecting the desired app for user to initiate the payment in
- Remove <queries> from demo app's AndroidManifest.xml as it is defined inside of the SDK itself from 3.2.0 onwards